### PR TITLE
Byte threshold

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let availabilityDefinition = PackageDescription.SwiftSetting.unsafeFlags([
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",
-    "SwiftStdlib 5.7:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999",
+    "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0",
     "-Xfrontend",
     "-define-availability",
     "-Xfrontend",

--- a/Sources/_StringProcessing/Engine/Processor.swift
+++ b/Sources/_StringProcessing/Engine/Processor.swift
@@ -91,6 +91,8 @@ struct Processor {
   var isTracingEnabled: Bool
   let shouldMeasureMetrics: Bool
   var metrics: ProcessorMetrics = ProcessorMetrics()
+
+  let fastUTF8: UnsafeRawBufferPointer? = nil
 }
 
 extension Processor {


### PR DESCRIPTION
Built on top of OS version availability PR: https://github.com/apple/swift-experimental-string-processing/pull/641


Get a recent enough toolchain (I'm using 2023-03-06) and build using:

```
xcrun --toolchain swift swift build -c release 
```

Build and run benchmark suite prior to 1ea82e6c5d965a46dda52381342540c9da4c4fa0:

```
.build/release/RegexBenchmark --samples 20 --save main_unmodified
```

Run again, comparing results:

```
.build/release/RegexBenchmark --samples 20 --compare main_unmodified
```

Results:

```
Comparing against saved benchmark result main_unmodified
=== Regressions ======================================================================
- CompilerMessagesAll                     129ms	118ms	11.1ms		9.4%
- EmailRFCNoMatchesAll                    142ms	133ms	9.01ms		6.8%
- EmojiRegexAll                           80.1ms	71.1ms	8.99ms		12.6%
- EmailRFCAll                             68.4ms	61.2ms	7.15ms		11.7%
- DiceRollsInTextAll                      71.7ms	66ms	5.75ms		8.7%
- EmailLookaheadNoMatchesAll              45.1ms	40.8ms	4.31ms		10.6%
- EmailBuiltinCharacterClassAll           28.5ms	26ms	2.45ms		9.4%
- EmailLookaheadAll                       41.5ms	39.2ms	2.22ms		5.7%
- symDiffCCC                              50ms	47.8ms	2.14ms		4.5%
- SubtractionCCC                          23ms	21ms	2.02ms		9.6%
- IntersectionCCC                         23.5ms	21.5ms	1.97ms		9.2%
- ReluctantQuantWhole                     15.8ms	13.8ms	1.96ms		14.1%
- ReluctantQuantWithTerminalWhole         10.5ms	8.99ms	1.53ms		17.0%
- LiteralSearchAll                        7.37ms	6.42ms	951µs		14.8%
- BasicCCC                                11.4ms	10.5ms	901µs		8.6%
- LiteralSearchNotFoundAll                7.11ms	6.25ms	866µs		13.9%
- BasicRangeCCC                           11.7ms	10.8ms	849µs		7.8%
- CaseInsensitiveCCC                      12.5ms	11.6ms	844µs		7.3%
- NotFoundAll                             7.76ms	6.93ms	832µs		12.0%
- AnchoredNotFoundWhole                   9.56ms	8.83ms	726µs		8.2%
- HangulSyllableAll                       7.36ms	6.66ms	698µs		10.5%
- CssAll                                  4.62ms	3.94ms	684µs		17.4%
- BasicBuiltinCharacterClassAll           16.5ms	15.9ms	673µs		4.2%
- InvertedCCC                             21.4ms	20.7ms	654µs		3.2%
- NumbersAll                              13ms	12.6ms	445µs		3.5%
- HangulSyllableFirst                     3.6ms	3.18ms	418µs		13.1%
- DiceNotation                            7.45ms	7.08ms	374µs		5.3%
- WordsAll                                23ms	22.6ms	348µs		1.5%
- EmailLookaheadList                      9.98ms	9.69ms	286µs		3.0%
- GraphemeBreakNoCapAll                   7.2ms	6.95ms	247µs		3.5%
- IPv4Address                             3.08ms	2.83ms	244µs		8.6%
- IPv6Address                             4.15ms	4.02ms	124µs		3.1%
- MACAddress                              3.09ms	2.98ms	103µs		3.5%
- LinesAll                                3.15ms	3.07ms	81.5µs		2.7%
- EagarQuantWithTerminalWhole             2.64ms	2.58ms	58.4µs		2.3%
```

(If the benchmark suite fatal errors out, that usually means the device was too variant. You can run it again. I'm going to probably increase the tolerance of this a little in the future).
